### PR TITLE
【ELB】调整日志级别及创建新ipgroup的默认名称 (#356)

### DIFF
--- a/tools/c7n_huaweicloud/c7n_huaweicloud/actions/elb.py
+++ b/tools/c7n_huaweicloud/c7n_huaweicloud/actions/elb.py
@@ -368,7 +368,7 @@ class LoadbalancerEnableLoggingAction(HuaweiCloudBaseAction):
                     resp_log_group_id = group.log_group_id
                     break
             if not resp_log_group_id:
-                log.error(
+                log.info(
                     f"[actions]-[{self.data.get('type', 'UnknownAction')}] "
                     f"Log group with specified log_group_id='{log_group_id}' not found."
                 )
@@ -379,7 +379,7 @@ class LoadbalancerEnableLoggingAction(HuaweiCloudBaseAction):
                     resp_log_group_id = group.log_group_id
                     break
             if not resp_log_group_id:
-                log.error(
+                log.info(
                     f"[actions]-[{self.data.get('type', 'UnknownAction')}] "
                     f"Log group with specified log_group_name='{log_group_name}' not found."
                 )
@@ -405,7 +405,7 @@ class LoadbalancerEnableLoggingAction(HuaweiCloudBaseAction):
                     resp_log_stream_id = topic.log_stream_id
                     break
             if not resp_log_stream_id:
-                log.error(
+                log.info(
                     f"[actions]-[{self.data.get('type', 'UnknownAction')}] "
                     f"Log topic with specified log_topic_id='{log_topic_id}' not found."
                 )
@@ -416,7 +416,7 @@ class LoadbalancerEnableLoggingAction(HuaweiCloudBaseAction):
                     resp_log_stream_id = topic.log_stream_id
                     break
             if not resp_log_stream_id:
-                log.error(
+                log.info(
                     f"[actions]-[{self.data.get('type', 'UnknownAction')}] "
                     f"Log topic with specified log_topic_name='{log_topic_name}' not found."
                 )
@@ -643,15 +643,16 @@ class ListenerSetAclIpgroupAction(HuaweiCloudBaseAction):
             raise Exception("ipgroup_id or ipgroup_name must be provided"
                             " in the policy action type 'set-acl-ipgroup'.")
 
+        ipgroup_name = len(ipgroup_names) > 0 and ipgroup_names[0] or ""
         ipgroups = []
         if creation == "always":
             ipgroups = [self.create_ipgroup(
-                "ipgroup_empty_by_custodian", ip_list, enterprise_project_name, description)]
+                ipgroup_name, ip_list, enterprise_project_name, description)]
         elif creation == "create-if-absent":
             all_finded, ipgroups = self.get_ipgroup(ipgroup_ids, ipgroup_names)
             if not all_finded:
                 ipgroups = [self.create_ipgroup(
-                    "ipgroup_empty_by_custodian", ip_list, enterprise_project_name, description)]
+                    ipgroup_name, ip_list, enterprise_project_name, description)]
         else:
             all_finded, ipgroups = self.get_ipgroup(ipgroup_ids, ipgroup_names)
             if not all_finded:


### PR DESCRIPTION
* add redirect listener filter and action support for ELB

* lint check

* lint check

* lint check

* elb test: redirect to listener

* 1、优化并格式化代码；2、log和ipgroup相关action增加支持name参数

* 1、调整方法顺序；2、lts服务名改为lts-stream；3、ipgroup列表查询返回读取错误修改；

* only support http redirect to https

* lint check

* lint check

* unstable ut, remove it

* 日志规范整改-elb

* ELB日志整改

* 日志优化

* format

* 超时和权限类异常不捕获，抛出外层

* 处理超时和权限403异常

* 915需求，新增创建云日志和ip地址组

* 格式化

* eps的字段暂不对客户开放

* ipgroup_id or ipgroup_name must be provided in the policy action type 'set-acl-ipgroup'.

* 调整日志级别及创建新ipgroup的默认名称

---------